### PR TITLE
Subdomains support (for TweetDeck)

### DIFF
--- a/default_popup/js/main.js
+++ b/default_popup/js/main.js
@@ -15,14 +15,14 @@ $(document).ready(function(){
     });
   };
   onPageLoad();
-  
+
   $('#input-rps').on('change', function() {
     chrome.storage.local.set({'rps': $('#input-rps').val()}, function () {});
   });
 
   $('#button-apply').on('click', function() {
     chrome.storage.local.set({'rps': $('#input-rps').val()}, function () {});
-    chrome.tabs.query({url: "*://twitter.com/*"}, function (tabs) {
+    chrome.tabs.query({url: "*://*.twitter.com/*"}, function (tabs) {
       tabs.forEach(function(tab){
          chrome.tabs.reload(tab.id);
       });

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://twitter.com/*"],
+      "matches": ["https://twitter.com/*", "https://tweetdeck.twitter.com/*"],
       "css": ["content_scripts/main.css"],
       "js": ["content_scripts/main.js"]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://twitter.com/*", "https://tweetdeck.twitter.com/*"],
+      "matches": ["https://*.twitter.com/*"],
       "css": ["content_scripts/main.css"],
       "js": ["content_scripts/main.js"]
     }


### PR DESCRIPTION
Hi, I do love this extension! It's pretty cool idea at all.

But I think I and other professional users usually use [TweetDeck](tweetdeck.twitter.com) than [twitter.com](twitter.com), so it would be cool if it also works in subdomains of twitter.com.

![twitter_rotate_tweetdeck_eg](https://user-images.githubusercontent.com/19276905/32049531-5504a958-ba88-11e7-9358-cb4c277a932e.gif)

Thanks for your time & your work